### PR TITLE
Fix credential token passing

### DIFF
--- a/src/KinesisProducerNet/Daemon.cs
+++ b/src/KinesisProducerNet/Daemon.cs
@@ -303,7 +303,7 @@ namespace KinesisProducerNet
                 SecretKey = immutableCredentials.SecretKey
             };
 
-            if (awsCredentials is SessionAWSCredentials)
+            if (immutableCredentials.UseToken)
             {
                 creds.Token = immutableCredentials.Token;
             }


### PR DESCRIPTION
When using the default credentials a token is never passed to the KPL, but often one is needed.